### PR TITLE
introduce properties for flags list

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -39,5 +39,8 @@ under the License.
         <requiredProperty key="netbeansVersion">
             <defaultValue>RELEASE110</defaultValue>
         </requiredProperty>
+        <requiredProperty key="addopensflagsList">
+            <defaultValue> </defaultValue>
+        </requiredProperty>
     </requiredProperties>
 </archetype-descriptor>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -11,6 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- jms flags prefix -->
+        <addopenflags>${addopensflagsList}</addopenflags>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This is the #2 followup to let NetBeans set the addopensflagsList properties itself. 
Should let end user configuring in only one place in case of evolution 