### PR TITLE
Added runtime parameter to open java.net

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -13,9 +13,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- NetBeans 22+ requires JDK 17+ -->
         <maven.compiler.release>17</maven.compiler.release>
+
+        <netbeans.run.params.local/>
+        <netbeans.run.params.ide/>
+        <netbeans.run.params>${netbeans.run.params.ide} ${netbeans.run.params.local} -J--add-opens=java.base/java.net=ALL-UNNAMED</netbeans.run.params>
         <jpms-flags>
             --add-opens=java.base/java.net=ALL-UNNAMED
-            <!-- add more "add opens" if needed -->
+            <!-- add more "add opens" if needed. Note that it must be added to netbeans.run.params if needed at runtime -->
         </jpms-flags>
     </properties>
 


### PR DESCRIPTION
Open `java.net` for a new NMB created with this archetype.

Adding this based on @mbien 's comment https://github.com/apache/netbeans-mavenutils-archetype-netbeans-platform-app-archetype/pull/20#issuecomment-3446559403